### PR TITLE
Corrected mismatched keys on relation data

### DIFF
--- a/provides.py
+++ b/provides.py
@@ -18,6 +18,6 @@ class PublicAddressProvides(RelationBase):
     def set_address_port(self, address, port):
         # Iterate over all conversations of this type to send data to everyone.
         for conversation in self.conversations():
-            client = {'address': address, 'port': port}
+            client = {'public-address': address, 'port': port}
             # Send the address and port to every unit using the conversation.
             conversation.set_remote(data=client)

--- a/requires.py
+++ b/requires.py
@@ -9,11 +9,12 @@ class PublicAddressRequires(RelationBase):
 
     @hook('{requires:public-address}-relation-{joined,changed}')
     def changed(self):
-        conversation = self.conversation()
-        if conversation.get_remote('port'):
-            # this unit's conversation has a port, so
+        conv = self.conversation()
+        conv.set_state('{relation_name}.connected')
+        if conv.get_remote('port') and conv.get_remote('public-address'):
+            # this unit's conversation has a port, and public-address so
             # it is part of the set of available units
-            conversation.set_state('{relation_name}.available')
+            conv.set_state('{relation_name}.available')
 
     @hook('{requires:public-address}-relation-{departed,broken}')
     def broken(self):


### PR DESCRIPTION
Also added a guard on the requiring side of the interface to not return
    available unless both public-address and port are availble. This will
    give consumers a stronger sense of not having to guard against empty
    values when consuming the interface.

fixes #1 
