### PR TITLE
Fix race where loadbalancer.available is not cleared early enough

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -1,6 +1,6 @@
 import json
 
-from charms.reactive import when, when_not
+from charms.reactive import when, hook
 from charms.reactive import set_flag, clear_flag
 from charms.reactive import Endpoint
 
@@ -14,9 +14,10 @@ class PublicAddressRequires(Endpoint):
                for unit in self.all_joined_units):
             set_flag(self.expand_name('{endpoint_name}.available'))
 
-    @when_not('endpoint.{endpoint_name}.joined')
+    @hook('{requires:public-address}-relation-departed')
     def broken(self):
-        clear_flag(self.expand_name('{endpoint_name}.available'))
+        if not self.is_joined:
+            clear_flag(self.expand_name('{endpoint_name}.available'))
 
     def get_addresses_ports(self):
         '''Returns a list of available HTTP providers and their associated

--- a/requires.py
+++ b/requires.py
@@ -1,11 +1,15 @@
 import json
 
-from charms.reactive import when, hook
-from charms.reactive import set_flag, clear_flag
-from charms.reactive import Endpoint
+from charms.reactive import when, set_flag, Endpoint
+from charms.reactive.flags import register_trigger
 
 
 class PublicAddressRequires(Endpoint):
+    def register_triggers(self):
+        register_trigger(
+            when_not=self.expand_name('endpoint.{endpoint_name}.joined'),
+            clear_flag=self.expand_name('{endpoint_name}.available')
+        )
 
     @when('endpoint.{endpoint_name}.changed')
     def changed(self):
@@ -13,11 +17,6 @@ class PublicAddressRequires(Endpoint):
                unit.received_raw['public-address']
                for unit in self.all_joined_units):
             set_flag(self.expand_name('{endpoint_name}.available'))
-
-    @hook('{requires:public-address}-relation-departed')
-    def broken(self):
-        if not self.is_joined:
-            clear_flag(self.expand_name('{endpoint_name}.available'))
 
     def get_addresses_ports(self):
         '''Returns a list of available HTTP providers and their associated


### PR DESCRIPTION
This fixes an error observed in CI. While removing a kubernetes-master unit, the `loadbalancer-relation-departed` hook blew up:

```
unit-kubernetes-master-0: 02:17:16 INFO unit.kubernetes-master/0.juju-log loadbalancer:2: Reactive main running for hook loadbalancer-relation-departed
...
unit-kubernetes-master-0: 02:17:21 INFO unit.kubernetes-master/0.juju-log loadbalancer:2: Invoking reactive handler: reactive/kubernetes_master.py:959:loadbalancer_kubeconfig
unit-kubernetes-master-0: 02:17:21 ERROR unit.kubernetes-master/0.juju-log loadbalancer:2: Hook error:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-kubernetes-master-0/.venv/lib/python3.6/site-packages/charms/reactive/__init__.py", line 73, in main
    bus.dispatch(restricted=restricted_mode)
  File "/var/lib/juju/agents/unit-kubernetes-master-0/.venv/lib/python3.6/site-packages/charms/reactive/bus.py", line 390, in dispatch
    _invoke(other_handlers)
  File "/var/lib/juju/agents/unit-kubernetes-master-0/.venv/lib/python3.6/site-packages/charms/reactive/bus.py", line 359, in _invoke
    handler.invoke()
  File "/var/lib/juju/agents/unit-kubernetes-master-0/.venv/lib/python3.6/site-packages/charms/reactive/bus.py", line 181, in invoke
    self._action(*args)
  File "/var/lib/juju/agents/unit-kubernetes-master-0/charm/reactive/kubernetes_master.py", line 965, in loadbalancer_kubeconfig
    address = hosts[0].get('public-address')
IndexError: list index out of range
```

The [loadbalancer_kubeconfig](https://github.com/juju-solutions/kubernetes/blob/d71f27ff3a247c3a41b9e09ef96cf333f7cb0cff/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py#L961) handler ran because `loadbalancer.available` was still set, even though the loadbalancer relation had no joined units. The `loadbalancer.available` flag wasn't cleared because [PublicAddressRequires.broken](https://github.com/juju-solutions/interface-public-address/blob/d09e1e50389a1230383830bb8727d9d6a0991938/requires.py#L18) had not run yet.

This bug was introduced by https://github.com/juju-solutions/interface-public-address/pull/3 when we switched from RelationBase to Endpoint, and in particular, switched from using a `@hook` handler to a `@when_not` handler to clear the `loadbalancer.available` flag.

This PR fixes it by reverting to a `@hook` handler for clearing the flag, which is guaranteed to run before `@when` handlers.