### PR TITLE
Fix sorting error on None values

### DIFF
--- a/requires.py
+++ b/requires.py
@@ -40,4 +40,6 @@ class PublicAddressRequires(Endpoint):
                     for ed in json.loads(data['extended_data']):
                         hosts.add((ed['public-address'], ed['port']))
 
-        return [{'public-address': pa, 'port': p} for pa, p in sorted(hosts)]
+        return [{'public-address': pa, 'port': p}
+                for pa, p in sorted(host for host in hosts
+                                    if None not in host)]


### PR DESCRIPTION
```python
  File "/var/lib/juju/agents/unit-kubernetes-master-0/charm/hooks/relations/public-address/requires.py", line 43, in get_addresses_ports
    return [{'public-address': pa, 'port': p} for pa, p in sorted(hosts)]
TypeError: '<' not supported between instances of 'NoneType' and 'str'
```